### PR TITLE
Formatting dates as DB strings

### DIFF
--- a/lib/date-utils.js
+++ b/lib/date-utils.js
@@ -276,6 +276,14 @@ THE SOFTWARE.
         }
     }
     
+    if (Date.prototype.toDBString === undefined) {
+        Date.prototype.toDBString = function () {
+            return this.getUTCFullYear() + '-' +  pad(this.getUTCMonth() + 1, 2) + 
+                   '-' + pad(this.getUTCDate(), 2) + ' ' + pad(this.getUTCHours(), 2) + 
+                   ':' + pad(this.getUTCMinutes(), 2) + ':' + pad(this.getUTCSeconds(), 2);
+        }
+    }    
+    
     if (Date.prototype.clearTime === undefined) {
         Date.prototype.clearTime = function () {
             this.setHours(0);

--- a/test/date-format.js
+++ b/test/date-format.js
@@ -37,6 +37,12 @@ vows.describe('Date Format').addBatch({
             date = new Date(date.valueOf() + date.getTimezoneOffset() * 60000);
             assert.equal(date.toCLFString(), '01/Jan/2011:01:01:01 ' + tz);
         }
-    }
+    },
     
+    'can return database formatted string': {
+        topic: function () { return new Date(Date.UTC(2011, 0, 1, 1, 1, 1, 0)) },
+        'returns the correct database string': function (date) {
+            assert.equal(date.toDBString(), '2011-01-01 01:01:01');
+        }
+    }
 }).run();


### PR DESCRIPTION
Hello, 

Using node-date-utils is very nice, but while using it with a mysql database, I found it wasn't able to format dates as DB strings so it can be saved into a Datetime column. I added a method to perform this transformation. From a date object you can have a db string like "2011-01-01 01:01:01". Also this date is converted to UTC, because most developers/frameworks (like Rails, for example) follow this pattern while working with datetime columns.

Everything was developed using TDD, so a new test has been inserted in the same commit.

Best regards,
Augusto Souza
