### PR TITLE
Fix for Date.prototype.toYMD() not acccepting empty string as separator

### DIFF
--- a/lib/date-utils.js
+++ b/lib/date-utils.js
@@ -498,7 +498,7 @@ THE SOFTWARE.
     });
 
     polyfill('toYMD', function (separator) {
-        separator = typeof separator === 'string' ? separator : '-';
+        separator = typeof separator === 'undefined' ? '-' : separator;
         return this.getFullYear() + separator + pad(this.getMonth() + 1, 2) +
             separator + pad(this.getDate(), 2);
     });


### PR DESCRIPTION
For a given date object:

```
var date = new Date('2011-08-28 UTC');
```

The behavior w/o this patch:

```
date.toYMD(''); // returns '2011-08-28'
```

Behavior w/ this patch:

```
date.toYMD(''); // returns '20110828'
```
