### PR TITLE
Adds UTCtoday, UTCyesterday, UTCtomorrow and clearUTCTime

### DIFF
--- a/lib/date-utils.js
+++ b/lib/date-utils.js
@@ -166,14 +166,14 @@ THE SOFTWARE.
     // getDateFromFormat( date_string , format_string )
     //
     // This function takes a date string and a format string. It matches
-    // If the date string matches the format string, it returns the 
+    // If the date string matches the format string, it returns the
     // getTime() of the date. If it does not match, it returns NaN.
     // Original Author: Matt Kruse <matt@mattkruse.com>
     // WWW: http://www.mattkruse.com/
     // Adapted from: http://www.mattkruse.com/javascript/date/source.html
     // ------------------------------------------------------------------
 
-    
+
     var getDateFromFormat = function (val, format) {
         val = val + "";
         format = format + "";
@@ -351,7 +351,7 @@ THE SOFTWARE.
         return newdate.getTime();
     };
 
-    
+
     /** @ignore */
     Date.parse = function (date, format) {
         if (format) {
@@ -390,6 +390,16 @@ THE SOFTWARE.
     };
 
     /**
+        Returns new instance of Date object with the date set to today and
+        the time set to midnight in UTC
+        @returns {Date} Today's Date in UTC
+        @function
+     */
+    Date.UTCtoday = function () {
+        return new Date().clearUTCTime();
+    };
+
+    /**
         Returns new instance of Date object with the date set to tomorrow and
         the time set to midnight
         @returns {Date} Tomorrow's Date
@@ -400,6 +410,16 @@ THE SOFTWARE.
     };
 
     /**
+        Returns new instance of Date object with the date set to tomorrow and
+        the time set to midnight in UTC
+        @returns {Date} Tomorrow's Date in UTC
+        @function
+     */
+    Date.UTCtomorrow = function () {
+        return Date.UTCtoday().add({days: 1});
+    };
+
+    /**
         Returns new instance of Date object with the date set to yesterday and
         the time set to midnight
         @returns {Date} Yesterday's Date
@@ -407,6 +427,16 @@ THE SOFTWARE.
      */
     Date.yesterday = function () {
         return Date.today().add({days: -1});
+    };
+
+    /**
+        Returns new instance of Date object with the date set to yesterday and
+        the time set to midnight in UTC
+        @returns {Date} Yesterday's Date in UTC
+        @function
+     */
+    Date.UTCyesterday = function () {
+        return Date.UTCtoday().add({days: -1});
     };
 
     Date.validateDay = function (day, year, month) {
@@ -504,8 +534,8 @@ THE SOFTWARE.
     });
 
     polyfill('toDBString', function () {
-        return this.getUTCFullYear() + '-' +  pad(this.getUTCMonth() + 1, 2) + 
-               '-' + pad(this.getUTCDate(), 2) + ' ' + pad(this.getUTCHours(), 2) + 
+        return this.getUTCFullYear() + '-' +  pad(this.getUTCMonth() + 1, 2) +
+               '-' + pad(this.getUTCDate(), 2) + ' ' + pad(this.getUTCHours(), 2) +
                ':' + pad(this.getUTCMinutes(), 2) + ':' + pad(this.getUTCSeconds(), 2);
     });
 
@@ -514,6 +544,15 @@ THE SOFTWARE.
         this.setMinutes(0);
         this.setSeconds(0);
         this.setMilliseconds(0);
+
+        return this;
+    });
+
+    polyfill('clearUTCTime', function () {
+        this.setUTCHours(0);
+        this.setUTCMinutes(0);
+        this.setUTCSeconds(0);
+        this.setUTCMilliseconds(0);
 
         return this;
     });
@@ -625,7 +664,7 @@ THE SOFTWARE.
     polyfill('getSecondsBetween', function (date) {
         return ((date.clone().valueOf() - this.valueOf()) / 1000) | 0;
     });
-    
+
     polyfill('getOrdinalNumber', function () {
         return Math.ceil((this.clone().clearTime() - new Date(this.getFullYear(), 0, 1)) / 86400000) + 1;
     });

--- a/test/date-new-test.js
+++ b/test/date-new-test.js
@@ -20,17 +20,40 @@ vows.describe('Date New').addBatch({
             compare.setMinutes(0);
             compare.setSeconds(0);
             compare.setMilliseconds(0);
-            
+
             assert.equal(date.valueOf(), compare.valueOf());
         }
     },
-    
+
+    'clearUTCTime() works': {
+        topic: function() { return new Date().clearUTCTime(); },
+        'returns the correct value': function (date) {
+            var compare = new Date();
+            compare.setUTCHours(0);
+            compare.setUTCMinutes(0);
+            compare.setUTCSeconds(0);
+            compare.setUTCMilliseconds(0);
+
+            assert.equal(date.valueOf(), compare.valueOf());
+        }
+    },
+
     'today() works': {
         topic: function() {
             return Date.today();
         },
         'returns the correct value': function(date) {
             var compare = new Date().clearTime();
+            assert.equal(date.valueOf(), compare.valueOf());
+        }
+    },
+
+    'UTCtoday() works': {
+        topic: function() {
+            return Date.UTCtoday();
+        },
+        'returns the correct value': function(date) {
+            var compare = new Date().clearUTCTime();
             assert.equal(date.valueOf(), compare.valueOf());
         }
     },
@@ -46,6 +69,17 @@ vows.describe('Date New').addBatch({
         }
     },
 
+    'UTCyesterday() works': {
+        topic: function() {
+            return Date.UTCyesterday();
+        },
+        'returns the correct value': function(date) {
+            var compare = new Date().clearUTCTime();
+            compare.setSeconds(compare.getSeconds() - 86400);
+            assert.equal(date.valueOf(), compare.valueOf());
+        }
+    },
+
     'tomorrow() works': {
         topic: function() {
             return Date.tomorrow();
@@ -55,6 +89,17 @@ vows.describe('Date New').addBatch({
             compare.setSeconds(compare.getSeconds() + 86400);
             assert.equal(date.valueOf(), compare.valueOf());
         }
+    },
+
+    'UTCtomorrow() works': {
+        topic: function() {
+            return Date.UTCtomorrow();
+        },
+        'returns the correct value': function(date) {
+            var compare = new Date().clearUTCTime();
+            compare.setSeconds(compare.getSeconds() + 86400);
+            assert.equal(date.valueOf(), compare.valueOf());
+        }
     }
-    
+
 }).export(module);

--- a/test/date-validate-test.js
+++ b/test/date-validate-test.js
@@ -16,7 +16,7 @@ vows.describe('Date Validate').addBatch({
             assert.equal(topic.validateHour(12), true);
         }
     },
-    
+
     'can deal with minutes': {
         topic: function () { return Date; },
         'false for less than 0': function (topic) {
@@ -29,7 +29,7 @@ vows.describe('Date Validate').addBatch({
             assert.equal(topic.validateMinute(30), true);
         }
     },
-    
+
     'can deal with seconds': {
         topic: function () { return Date; },
         'false for less than 0': function (topic) {
@@ -42,7 +42,7 @@ vows.describe('Date Validate').addBatch({
             assert.equal(topic.validateSecond(30), true);
         }
     },
-    
+
     'can deal with milliseconds': {
         topic: function () { return Date; },
         'false for less than 0': function (topic) {
@@ -55,7 +55,7 @@ vows.describe('Date Validate').addBatch({
             assert.equal(topic.validateMillisecond(500), true);
         }
     },
-    
+
     'can deal with years': {
         topic: function () { return Date; },
         'false for less than 0': function (topic) {
@@ -68,7 +68,7 @@ vows.describe('Date Validate').addBatch({
             assert.equal(topic.validateYear(5000), true);
         }
     },
-    
+
     'can deal with days': {
         topic: function () { return Date; },
         'false for less than 0': function (topic) {
@@ -81,7 +81,7 @@ vows.describe('Date Validate').addBatch({
             assert.equal(topic.validateDay(10, 2011, 11), true);
         }
     },
-    
+
     'static compare works': {
         topic: function () { return Date.today(); },
         '-1 for yesterday': function (topic) {
@@ -94,7 +94,7 @@ vows.describe('Date Validate').addBatch({
             assert.equal(Date.compare(Date.today(), topic), 0);
         }
     },
-    
+
     'static equals works': {
         topic: function () { return Date.today(); },
         'equal for today': function (topic) {
@@ -107,7 +107,7 @@ vows.describe('Date Validate').addBatch({
             assert.equal(Date.equals(topic, Date.yesterday()), false);
         }
     },
-    
+
     'getDayNumberFromName works': {
         topic: function () { return Date; },
         'sunday works': function (topic) {
@@ -177,7 +177,7 @@ vows.describe('Date Validate').addBatch({
             assert.equal(topic.getDayNumberFromName('junk'), undefined);
         }
     },
-    
+
     'getMonthNumberFromName works': {
         topic: function () { return Date; },
         'january works': function (topic) {
@@ -250,7 +250,7 @@ vows.describe('Date Validate').addBatch({
             assert.equal(topic.getMonthNumberFromName('dec'), 11);
         }
     },
-    
+
     'can add milliseconds': {
         'adding positive milliseconds works': function () {
             var topic = Date.today();
@@ -265,7 +265,7 @@ vows.describe('Date Validate').addBatch({
             assert.equal(topic.getMilliseconds(), 250);
         }
     },
-    
+
     'can add seconds': {
         'adding positive seconds works': function () {
             var topic = Date.today();
@@ -295,7 +295,7 @@ vows.describe('Date Validate').addBatch({
             assert.equal(topic.getMinutes(), 25);
         }
     },
-    
+
     'can add hours': {
         'adding positive hours works': function () {
             var topic = Date.today();
@@ -325,7 +325,7 @@ vows.describe('Date Validate').addBatch({
             assert.equal(topic.getDate(), 9);
         }
     },
-    
+
     'can add weeks': {
         'adding positive weeks works': function () {
             var topic = new Date(2011, 0, 10);
@@ -374,7 +374,7 @@ vows.describe('Date Validate').addBatch({
             assert.equal(clone.valueOf(), topic.valueOf());
         }
     },
-    
+
     'between works': {
         'between returns true for valid start and end': function () {
             var today = Date.today();
@@ -389,7 +389,7 @@ vows.describe('Date Validate').addBatch({
             assert.equal(today.between(tomorrow, yesterday), false);
         }
     },
-    
+
     'compareTo works': {
         topic: function () { return Date.today(); },
         '-1 for tomorrow': function (topic) {
@@ -402,7 +402,7 @@ vows.describe('Date Validate').addBatch({
             assert.equal(topic.compareTo(Date.today()), 0);
         }
     },
-    
+
 
     'equals instance works': {
         topic: function () { return Date.today(); },
@@ -433,7 +433,7 @@ vows.describe('Date Validate').addBatch({
             assert.equal(topic.isAfter(Date.yesterday()), true);
         }
     },
-    
+
     'getDaysBetween works': {
         topic: function () { return Date.today(); },
         '1 for tomorrow': function (topic) {
@@ -446,7 +446,7 @@ vows.describe('Date Validate').addBatch({
             assert.equal(topic.getDaysBetween(Date.today()), 0);
         }
     },
-    
+
     'getDaysBetween works for beginning of year': {
         topic: function () {  return new Date('Jan 1, 2011 01:01:01 GMT'); },
         'should return 0 for the same day': function (topic) {
@@ -556,5 +556,5 @@ vows.describe('Date Validate').addBatch({
             assert.equal(Date.getDaysInMonth(2011, 11), 31);
         }
     }
-    
+
 }).export(module);


### PR DESCRIPTION
Needed "today" in UTC instead of in my local time zone.

PS. 9 tests fail for me over here due to time zone offset issues I think:

```
can parse custom format
  ✗ returns a correct value
    » expected 1308519000000,
      got      1308522600000 (==) // date-parse-test.js:54
parse custom format with full month name
  ✗ returns a correct value
    » expected 1308519000000,
      got      1308522600000 (==) // date-parse-test.js:62
parse custom format with abbr month name
  ✗ returns a correct value
    » expected 1308519000000,
      got      1308522600000 (==) // date-parse-test.js:70
parse custom format with 12 hr clock
  ✗ returns a correct value
    » expected 1308519000000,
      got      1308522600000 (==) // date-parse-test.js:78
parse mysql date format
  ✗ returns a correct value
    » expected 1308519000000,
      got      1308522600000 (==) // date-parse-test.js:86
parse us date format w/o time
  ✗ returns a correct value
    » expected 1308488400000,
      got      1308492000000 (==) // date-parse-test.js:94
parse us date format with time
  ✗ returns a correct value
    » expected 1308488401000,
      got      1308492001000 (==) // date-parse-test.js:102
parse uk date format w/o time
  ✗ returns a correct value
    » expected 1308488400000,
      got      1308492000000 (==) // date-parse-test.js:110
parse uk date format with time
  ✗ returns a correct value
    » expected 1308488401000,
      got      1308492001000 (==) // date-parse-test.js:119
```
