### PR TITLE
toFormat fix/add and updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,23 @@ Note: This did not work in the `REPL` before `Node.js 0.6` due to how `Node.js` 
     d.getOrdinalNumber(); // day number of the year, 1-366 (leap year)
     d.clearTime(); // sets time to 00:00:00
     d.setTimeToNow(); // sets time to current time
-    
     d.toFormat(format); // returns date formatted with:
-    // YYYY - Four digit year
-    // MMMM  - Full month name. ie January
-    // MMM  - Short month name. ie Jan
-    // MM   - Zero padded month ie 01
-    // M    - Month ie 1
-    // DDDD - Full day or week name , DDD, DD, D, HH, H, HH24, MI, SS
+      // YYYY - Four digit year
+      // MMMM - Full month name. ie January
+      // MMM  - Short month name. ie Jan
+      // MM   - Zero padded month ie 01
+      // M    - Month ie 1
+      // DDDD - Full day or week name ie Tuesday 
+      // DDD  - Abbreviated day of the week ie Tue
+      // DD   - Zero padded day ie 08
+      // D    - Day ie 8
+      // HH24 - Hours in 24 notation ie 18
+      // HH   - Padded Hours ie 06
+      // H    - Hours ie 6
+      // MI   - Padded Minutes
+      // SS   - Padded Seconds
+      // PP   - AM or PM
+      // P    - am or pm
     d.toYMD(separator); // returns YYYY-MM-DD by default, separator changes delimiter
     
     d.between(date1, date2); // true/false if the date/time is between date1 and date2

--- a/lib/date-utils.js
+++ b/lib/date-utils.js
@@ -690,6 +690,7 @@ THE SOFTWARE.
     });
 
     polyfill('toFormat', function (format) {
+        var hours = (this.getHours() % 12) ? this.getHours() % 12 : 12;
         format = format.replace('YYYY', this.getFullYear());
         format = format.replace('YY', String(this.getFullYear()).slice(-2));
         format = format.replace('MMMM', monthsFull[this.getMonth()]);
@@ -702,9 +703,11 @@ THE SOFTWARE.
         format = format.replace('DD', pad(this.getDate(), 2));
         format = format.replace('D', this.getDate());
         format = format.replace('HH24', pad(this.getHours(), 2));
-        format = format.replace('HH', pad((this.getHours() % 12), 2));
-        format = format.replace('H', this.getHours() % 12);
+        format = format.replace('HH', pad(hours, 2));
+        format = format.replace('H', hours);
         format = format.replace('SS', pad(this.getSeconds(), 2));
+        format = format.replace('P', (this.getHours() >= 12) ? 'pm' : 'am');
+        format = format.replace('PP', (this.getHours() >= 12) ? 'PM' : 'AM');
 
         return format;
     });


### PR DESCRIPTION
toFormat was using .getDate() % 12 for H and HH, which would eval to 0 when noon and midnight. Also added P and PP for AM/PM and am/pm in toFormat. Then I made the README more verbose and added the P and PP rules. NOTE: I did NOT update the .min version, figured I'd let you take care of that
