### PR TITLE
make vows a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "lib": "./lib",
         "test": "./test"
     },
-    "dependencies": { "vows": ">0.4.0" },
+    "devDependencies": { "vows": ">0.4.0" },
     "scripts": {
         "test": "vows --spec"
     },


### PR DESCRIPTION
So it and its dependencies don't get installed when you just want to use date-utils in node

Cheers!
