### PR TITLE
Get Last Month Name & Get Month Name By Number

### DIFF
--- a/lib/date-utils.js
+++ b/lib/date-utils.js
@@ -505,6 +505,9 @@ THE SOFTWARE.
         return date1.valueOf() === date2.valueOf();
     };
 
+    Date.equalsDay = function (date1, date2) {
+        return date1.toYMD() === date2.toYMD();
+    };
 
     Date.getDayNumberFromName = function (name) {
         return dayNames[name.toLowerCase()];
@@ -676,6 +679,14 @@ THE SOFTWARE.
 
     polyfill('equals', function (date) {
         return Date.equals(this, date);
+    });
+
+    polyfill('equalsDay', function (date) {
+        return Date.equalsDay(this, date);
+    });
+
+    polyfill('isToday', function () {
+        return Date.equalsDay(this, Date.today());
     });
 
     polyfill('isAfter', function (date) {

--- a/test/date-validate-test.js
+++ b/test/date-validate-test.js
@@ -108,6 +108,16 @@ vows.describe('Date Validate').addBatch({
         }
     },
 
+    'static equalsDay works': {
+        topic: function () { return Date.today(); },
+        'true for today': function (topic) {
+            assert.equal(Date.equalsDay(topic, Date.today()), true);
+        },
+        'false for yesterday': function (topic) {
+            assert.equal(Date.equalsDay(topic, Date.yesterday()), false);
+        },
+    },
+
     'getDayNumberFromName works': {
         topic: function () { return Date; },
         'sunday works': function (topic) {
@@ -582,6 +592,15 @@ vows.describe('Date Validate').addBatch({
         }
     },
 
+    'isToday works': {
+        topic: function () { return Date.today(); },
+        'true for today': function (topic) {
+            assert.equal(topic.isToday(), true);
+        },
+        'false if not today': function (topic) {
+            assert.equal(Date.yesterday().isToday(), false);
+        }
+    },
 
     'equals instance works': {
         topic: function () { return Date.today(); },
@@ -590,6 +609,16 @@ vows.describe('Date Validate').addBatch({
         },
         'false for not equal': function (topic) {
             assert.equal(topic.equals(Date.tomorrow()), false);
+        }
+    },
+
+    'equalsDay instance works': {
+        topic: function () { return Date.today(); },
+        'true for today': function (topic) {
+            assert.equal(topic.equalsDay(Date.today()), true);
+        },
+        'false for yesterday': function (topic) {
+            assert.equal(topic.equalsDay(Date.yesterday()), false);
         }
     },
 


### PR DESCRIPTION
Retrieve the name of previous month based on the date object

``` javascript
d.getLastMonthName(); // fill last month name, January, February, etc
```

Retrieve the name/abbreviation of a month based on the provided number

``` javascript
Date.getMonthNameFromNumber(); // 0 -  January, 1 - February, etc
Date.getMonthAbbrFromNumber(); // 0 - Jan, 1 - Feb, etc
```
