### PR TITLE
Adds getMonthsBetween

### DIFF
--- a/lib/date-utils.js
+++ b/lib/date-utils.js
@@ -697,38 +697,38 @@ THE SOFTWARE.
     polyfill('getMonthsBetween', function (date) {
 		// make a guess at the answer; using 31 means that we'll be close but won't exceed
 		var daysDiff, daysInMonth,
-			months = Math.ceil( new Date(date - this).getDate() / 31 ) ,			
+			months = Math.ceil( new Date(date - this).getUTCDate() / 31 ) ,
 			testDate = new Date( this.getTime() ),
 			totalDays = Date.getDaysInMonth; 
-		
+
 		// find the maximum number of months that's less than or equal to the end date
-		testDate.addMonths( months );
+		testDate.setUTCMonth( testDate.getUTCMonth() + months );
 		while ( testDate.getTime() < date.getTime() ) {
-			testDate.addMonths( 1 );
+            testDate.setUTCMonth( testDate.getUTCMonth() + 1 );
 			months++;
 		}
 
 		if ( testDate.getTime() !== date.getTime() ) {
 			// back off 1 month since we exceeded the end date
-			testDate.addMonths( -1 );
-			months--;			
+			testDate.setUTCMonth( testDate.getUTCMonth() - 1 );
+			months--;
 		}
 		
-		if ( date.getMonth() === testDate.getMonth() ) {
-			daysDiff = new Date( date - testDate ).getDate();
-			daysInMonth = totalDays( testDate.getFullYear(), testDate.getMonth() );		
+		if ( date.getUTCMonth() === testDate.getUTCMonth() ) {
+			daysDiff = new Date( date - testDate ).getUTCDate();
+			daysInMonth = totalDays( testDate.getUTCFullYear(), testDate.getUTCMonth() );
 			
 			return months + ( daysDiff / daysInMonth );
 		} else {
-			// if two date are on different months,
+			// if two dates are on different months,
 			// the calculation must be done for each separate month
 			// because their number of days can be different
-			daysInMonth = totalDays( testDate.getFullYear(), testDate.getMonth() );
-			daysDiff  = daysInMonth - testDate.getDate() + 1;			
+			daysInMonth = totalDays( testDate.getUTCFullYear(), testDate.getUTCMonth() );
+			daysDiff  = daysInMonth - testDate.getUTCDate() + 1;
 			
 			return months +
 					(+( daysDiff / daysInMonth ).toFixed( 5 )) +
-					(+( date.getDate() / totalDays( date.getFullYear(), date.getMonth() ) ).toFixed( 5 ));
+					(+( date.getUTCDate() / totalDays( date.getUTCFullYear(), date.getUTCMonth() ) ).toFixed( 5 ));
 		}
 	});
 

--- a/test/date-validate-test.js
+++ b/test/date-validate-test.js
@@ -571,17 +571,17 @@ vows.describe('Date Validate').addBatch({
     },
         
     'getMonthsBetween works': {
-		topic: function() { return new Date( "Feb 28 2013" ); },
+		topic: function() { return new Date( Date.UTC(2013, 1, 28) ); },
 		'different months': function( topic ) {			
-			var eDate = new Date( "Mar 30 2013" );
+			var eDate = new Date( Date.UTC(2013, 2, 30) );
 			assert.equal( topic.getMonthsBetween( eDate ).toFixed( 5 ), 1.09677 );
 		},
 		'different months and years': function( topic ) {
-			var eDate = new Date( "Apr 04 2014" );
+			var eDate = new Date( Date.UTC(2014, 3, 4) );
 			assert.equal( topic.getMonthsBetween( eDate ).toFixed( 5 ), 13.26236 );
 		},
 		'same month': function( topic ) {
-			var sDate = new Date( "Feb 01 2013" );
+			var sDate = new Date( Date.UTC(2013, 1, 1) );
 			assert.equal( sDate.getMonthsBetween( topic ).toFixed( 5 ), 1 ); 
 		},
 		'same date': function( topic ) {
@@ -589,7 +589,7 @@ vows.describe('Date Validate').addBatch({
 			assert.equal( topic.getMonthsBetween( sameDate ).toFixed( 5 ), 0.03571 );
 		},
 		'same day and month but different years': function( topic ) {
-			var differentYear = new Date( "Feb 28 2014" );
+			var differentYear = new Date( Date.UTC(2014, 1, 28) );
 			assert.equal( topic.getMonthsBetween( differentYear ).toFixed( 5 ), 12.03571 );	
 		}	
 	}


### PR DESCRIPTION
This new method allows to compute the number of months between two dates. Example usage:

``` javascript
var sDate = new Date(  "Feb 28 2013" );
assert.equal( sDate.getMonthsBetween(  new Date( "Mar 30 2013" ) ).toFixed( 5 ), 1.09677 );
```

Note that the return value is always a decimal value even if two dates are identical. So the following code will return <code>0.03571</code> rather than <code>0</code>

``` javascript
var sDate = new Date(  "Feb 28 2013" );
assert.equal( sDate.getMonthsBetween( new Date( sDate.getTime() ) ).toFixed( 5 ), 0.03571 );
```
