### PR TITLE
Expose the date as the module return.

### DIFF
--- a/lib/date-utils.js
+++ b/lib/date-utils.js
@@ -1477,4 +1477,8 @@ THE SOFTWARE.
             'LL': pad(date.getUTCMilliseconds(), 3)
         };
     };
+    
+    if (typeof module != 'undefined') {
+    	module.exports = Date;
+    }
 }());


### PR DESCRIPTION
Maybe it's better to return something after calling the `require(...)` function. 
