### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,7 @@
       "web": "http://legitimatesounding.com"
     }
   ],
-  "license": [
-    "MIT"
-  ],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "http://github.com/JerrySievert/date-utils.git"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/